### PR TITLE
#22, #23, #24 finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,17 @@
 
 ## Version 3.0.2
 
+### 2019-08-02
+
+1. Add `Go`, `JSON` highlight support
+2. Remove `HTML` highlight support
+
 ### 2019-08-01
 
 1. Fix [#22](https://github.com/LucienShui/PasteMeFrontend/issues/22) copy nothing in markdown parsed page
 2. Add tooltip on copy link in success page [#24](https://github.com/LucienShui/PasteMeFrontend/issues/24)
 3. Simplify PasteView page
 4. Add limit on footer refresh [#23](https://github.com/LucienShui/PasteMeFrontend/issues/23)
-5. Add `Go`, `JSON` highlight support
-6. Remove `HTML` highlight support
 
 ### 2019-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Version 3.0.2
 
+### 2019-08-01
+
+1. Fix [#22](https://github.com/LucienShui/PasteMeFrontend/issues/22) copy nothing in markdown parsed page
+2. Add tooltip on copy link in success page [#24](https://github.com/LucienShui/PasteMeFrontend/issues/24)
+3. Simplify PasteView page
+4. Add limit on footer refresh [#23](https://github.com/LucienShui/PasteMeFrontend/issues/23)
+5. Add `Go`, `JSON` highlight support
+6. Remove `HTML` highlight support
+
 ### 2019-07-24
 
 1. Add copy back

--- a/src/assets/js/hljs.js
+++ b/src/assets/js/hljs.js
@@ -7,7 +7,7 @@ import '../css/highlightjs-line-numbers.css'
 
 register(hljs, window, document);
 
-let langList = ['cpp', 'java', 'bash', 'http', 'python', 'markdown', 'plaintext'];
+let langList = ['cpp', 'java', 'bash', 'json', 'python', 'markdown', 'plaintext', 'go'];
 
 langList.forEach(function (lang) {
     hljs.registerLanguage(lang, require('highlight.js/lib/languages/' + lang));
@@ -26,5 +26,3 @@ Vue.directive('hljs', el => {
         });
     }
 });
-
-export default hljs;

--- a/src/assets/lang/zh-CN.js
+++ b/src/assets/lang/zh-CN.js
@@ -113,6 +113,8 @@ export const lang = {
             html: 'HTML',
             python: 'Python',
             markdown: 'Markdown',
+            go: 'Go',
+            json: 'JSON',
             plaintext: '纯文本'
         },
         copy: '复制',

--- a/src/assets/lang/zh-CN.js
+++ b/src/assets/lang/zh-CN.js
@@ -112,8 +112,9 @@ export const lang = {
             markdown: 'Markdown',
             plaintext: '纯文本'
         },
-        copy: {
-            copy: '复制',
+        copy: '复制',
+        tooltip: {
+            click: '点按以复制',
             success: '成功',
             fail: '失败'
         }

--- a/src/assets/lang/zh-CN.js
+++ b/src/assets/lang/zh-CN.js
@@ -97,7 +97,10 @@ export const lang = {
         }
     },
     footer: {
-        tooltip: '点击以刷新'
+        tooltip: {
+            refresh: '点按以刷新',
+            wait: '{sec} 秒后可以再次刷新'
+        }
     },
     view: {
         parsed: '渲染',

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -3,6 +3,7 @@
         <div class="col-md-12">
             <div class="footer">
                 <p><a id="one-word" style="cursor: pointer;" @click="refresh">{{ oneWord }}</a></p>
+                <b-tooltip target="one-word">{{ cut_down_time === 0 ? $t('lang.footer.tooltip.refresh') : $t('lang.footer.tooltip.wait', { sec: cut_down_time }) }}</b-tooltip>
                 <p>
                     <a href='http://blog.lucien.ink' target='_blank'>Lucien's Blog</a>
                     <a v-for="footer in $store.state.config.footer" v-bind:key="footer.id">&nbsp;&nbsp;|&nbsp;&nbsp;<a :href="footer.url" target="_blank">{{ footer.text }}</a></a>
@@ -14,7 +15,6 @@
                 </p>
             </div>
         </div>
-        <b-tooltip target="one-word" placement="topright">{{ $t('lang.footer.tooltip') }}</b-tooltip>
     </div>
 </template>
 
@@ -25,10 +25,13 @@
             return {
                 oneWord: 'Loading...',
                 year: new Date().getFullYear(),
+                cut_down_time: 0,
             }
         },
         mounted() {
-            this.refresh();
+            this.getOne().then(result => {
+                this.oneWord = result;
+            })
         },
         methods: {
             async getOne() {
@@ -43,9 +46,19 @@
                 return one;
             },
             refresh() {
-                this.getOne().then(result => {
-                    this.oneWord = result;
-                });
+                if (this.cut_down_time === 0) {
+                    this.oneWord = 'Loading...';
+                    this.getOne().then(result => {
+                        this.oneWord = result;
+                        this.cut_down_time = 5;
+                        let clock = window.setInterval(() => {
+                            this.cut_down_time--;
+                            if (this.cut_down_time === 0) {
+                                window.clearInterval(clock);
+                            }
+                        }, 1000);
+                    });
+                }
             }
         }
     }

--- a/src/components/Form.vue
+++ b/src/components/Form.vue
@@ -14,7 +14,8 @@
                                     <option value="python">Python</option>
                                     <option value="bash">Bash</option>
                                     <option value="markdown">Markdown</option>
-                                    <option value="html">HTML</option>
+                                    <option value="json">JSON</option>
+                                    <option value="go">Go</option>
                                 </b-form-select>
                             </b-input-group>
                         </b-form-group>

--- a/src/components/PasteView.vue
+++ b/src/components/PasteView.vue
@@ -2,7 +2,7 @@
     <b-row>
         <b-col md="1"></b-col>
         <b-col md="10">
-            <div v-if="$parent.lang === 'markdown'">
+            <div>
                 <b-card no-body>
                     <b-card-header>
                         <b-row>
@@ -15,19 +15,22 @@
                             </b-col>
                             <b-col md="6" style="text-align: right;">
                                 <b-check-group switches>
-                                    <b-checkbox v-model="raw">源码</b-checkbox>
-                                    <b-link class="clipboard-btn" :data-clipboard-text="$parent.content">
-                                        {{ $t('lang.view.copy.' +
-                                        (copy_btn_status > 0 ? 'success' : (copy_btn_status === 0 ?  'copy' : 'fail')))  }}
+                                    <b-checkbox v-model="raw" v-show="$parent.lang === 'markdown'">源码</b-checkbox>
+                                    <b-link id="clipboard-btn" :data-clipboard-text="$parent.content">
+                                        {{ $t('lang.view.copy') }}
                                     </b-link>
+                                    <b-tooltip show target="clipboard-btn" placement="bottomleft">
+                                        {{ $t('lang.view.tooltip.' + (copy_btn_status > 0 ? 'success' :
+                                            (copy_btn_status === 0 ?  'click' : 'fail'))) }}
+                                    </b-tooltip>
                                 </b-check-group>
                             </b-col>
                         </b-row>
                     </b-card-header>
-                    <b-card-body style="padding-bottom: 0" v-hljs v-show="raw.length === 1">
+                    <b-card-body style="padding-bottom: 0" v-hljs v-if="$parent.lang !== 'markdown' || raw.length === 1">
                         <pre><code v-bind:class="'line-numbers ' + $parent.lang" v-text="this.$parent.content"></code></pre>
                     </b-card-body>
-                    <b-card-body style="padding-bottom: 0" v-hljs v-show="raw.length === 0">
+                    <b-card-body style="padding-bottom: 0" v-hljs v-else>
                         <div class="markdown-body">
                             <div v-html="markdown.render($parent.content)"></div>
                             <script type="text/x-mathjax-config">
@@ -54,30 +57,6 @@
                     </b-card-body>
                 </b-card>
             </div>
-            <div v-else>
-                <b-card no-body>
-                    <b-card-header>
-                        <b-row>
-                            <b-col md="6">
-                                <div>
-                                    <a>{{ linesCount }} 行</a>
-                                    <a>&nbsp;|&nbsp;</a>
-                                    <a>{{ $t('lang.view.lang.' + $parent.lang) }}</a>
-                                </div>
-                            </b-col>
-                            <b-col md="6" style="text-align: right">
-                                <b-link href="#" class="clipboard-btn" data-clipboard-target=".hljs">
-                                    {{ $t('lang.view.copy.' +
-                                    (copy_btn_status > 0 ? 'success' : (copy_btn_status === 0 ?  'copy' : 'fail')))  }}
-                                </b-link>
-                            </b-col>
-                        </b-row>
-                    </b-card-header>
-                    <b-card-body style="padding-bottom: 0" v-hljs>
-                        <pre><code v-bind:class="'line-numbers ' + $parent.lang" v-text="this.$parent.content"></code></pre>
-                    </b-card-body>
-                </b-card>
-            </div>
         </b-col>
         <b-col md="1"></b-col>
     </b-row>
@@ -94,7 +73,7 @@
             }
         },
         mounted() {
-            let clipboard = new this.clipboard('.clipboard-btn');
+            let clipboard = new this.clipboard('#clipboard-btn');
             let cur = this;
             clipboard.on('success', function() {
                 cur.copy_btn_status = 1;

--- a/src/components/PasteView.vue
+++ b/src/components/PasteView.vue
@@ -16,7 +16,7 @@
                             <b-col md="6" style="text-align: right;">
                                 <b-check-group switches>
                                     <b-checkbox v-model="raw">源码</b-checkbox>
-                                    <b-link class="clipboard-btn" data-clipboard-target=".hljs">
+                                    <b-link class="clipboard-btn" :data-clipboard-text="$parent.content">
                                         {{ $t('lang.view.copy.' +
                                         (copy_btn_status > 0 ? 'success' : (copy_btn_status === 0 ?  'copy' : 'fail')))  }}
                                     </b-link>


### PR DESCRIPTION
## Version 3.0.2

### 2019-08-02

1. Add `Go`, `JSON` highlight support
2. Remove `HTML` highlight support

### 2019-08-01

1. Fix [#22](https://github.com/LucienShui/PasteMeFrontend/issues/22) copy nothing in markdown parsed page
2. Add tooltip on copy link in success page [#24](https://github.com/LucienShui/PasteMeFrontend/issues/24)
3. Simplify PasteView page
4. Add limit on footer refresh [#23](https://github.com/LucienShui/PasteMeFrontend/issues/23)